### PR TITLE
Fixed `activate` script generation and other bugs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 `kerl-fish` is [fish](http://fishshell.com) version of [kerl](https://github.com/yrashk/kerl).
 
-## TODO
+## Usage
 
-Most of things.
+Just like [kerl](https://github.com/yrashk/kerl) but run it in a fish shell.

--- a/kerl.fish
+++ b/kerl.fish
@@ -1,3 +1,4 @@
+#! /bin/fish
 
 # set CMDNAME (basename (status --current-filename))
 set ERLANG_DOWNLOAD_URL "http://www.erlang.org/download"
@@ -648,7 +649,7 @@ function kerl_download
     end
     kerl_ensure_checksum_file
     echo "Verifying archive checksum..."
-    set -l SUM ($MD5SUM "$KERL_DOWNLOAD_DIR/$argv[1]" | cut -d " " -f $MD5SUM_FIELD)
+    set -l SUM (eval $MD5SUM "$KERL_DOWNLOAD_DIR/$argv[1]" | cut -d " " -f $MD5SUM_FIELD)
     set -l ORIG_SUM (grep -F "$argv[1]" "$KERL_DOWNLOAD_DIR/MD5" | cut -d " " -f 2)
     if test "$SUM" != "$ORIG_SUM"
         echo "Checksum error, check the files in $KERL_DOWNLOAD_DIR"
@@ -829,3 +830,5 @@ function kerl
             echo "unknown command: $argv[1]"; kerl_usage; return 1
     end
 end
+
+kerl $argv

--- a/kerl.fish
+++ b/kerl.fish
@@ -1,4 +1,4 @@
-#! /bin/fish
+#! /usr/bin/fish
 
 # set CMDNAME (basename (status --current-filename))
 set ERLANG_DOWNLOAD_URL "http://www.erlang.org/download"
@@ -79,7 +79,7 @@ switch $KERL_SYSTEM
         set MD5SUM_FIELD 2
         set SED_OPT -E
     case '*'
-        set MD5SUM md5sun
+        set MD5SUM md5sum
         set MD5SUM_FIELD 1
         set SED_OPT -r
 end
@@ -221,7 +221,7 @@ end
 function kerl_do_git_build
     kerl_assert_build_name_unused $argv[3]
 
-    set -l GIT (echo -n "$argv[1]" | $MD5SUM | cut -d " " -f $MD5SUM_FIELD)
+    set -l GIT (echo -n "$argv[1]" | "$MD5SUM" | cut -d " " -f $MD5SUM_FIELD)
     mkdir -p "$KERL_GIT_DIR"
     cd "$KERL_GIT_DIR"
     echo "Checking Erlang/OTP git repository from $argv[1]..."

--- a/kerl.fish
+++ b/kerl.fish
@@ -663,18 +663,18 @@ function kerl
 
     switch "$argv[1]"
         case build
-            if test "$argv[2]" = "git"
-                if test (count $argv) -ne 5
+            if test (count $argv) = 5
+                if test "$argv[2]" != "git"
                     echo "usage: kerl $argv[1] $argv[2] <git_url> <git_version> <build_name>"
                     return 1
                 end
                 kerl_do_git_build $argv[3] $argv[4] $argv[5]
-            else
-                if test (count $argv) -lt 3
-                    echo "usage: kerl $argv[1] <release> <build_name>"
-                    return 1
-                end
+            else if test (count $argv) = 3
                 kerl_do_build $argv[2] $argv[3]
+            else
+                echo "usage: kerl $argv[1] <release> <build_name>"
+                echo "usage: kerl $argv[1] git <git_url> <git_version> <build_name>"
+                return 1
             end
         case install
             if test (count $argv) -lt 2

--- a/kerl.fish
+++ b/kerl.fish
@@ -221,7 +221,7 @@ end
 function kerl_do_git_build
     kerl_assert_build_name_unused $argv[3]
 
-    set -l GIT (echo -n "$argv[1]" | "$MD5SUM" | cut -d " " -f $MD5SUM_FIELD)
+    set -l GIT (echo -n "$argv[1]" | eval $MD5SUM | cut -d " " -f $MD5SUM_FIELD)
     mkdir -p "$KERL_GIT_DIR"
     cd "$KERL_GIT_DIR"
     echo "Checking Erlang/OTP git repository from $argv[1]..."

--- a/kerl.fish
+++ b/kerl.fish
@@ -384,7 +384,7 @@ function kerl_do_build
 end
 
 function kerl_do_install
-    set -l rel (kerl_get_release_from_name $argv[1])
+    set -l rel (eval kerl_get_release_from_name $argv[1])
     if test $status -ne 0
         echo "No build named $argv[1]"
         return 1
@@ -407,56 +407,53 @@ function kerl_do_install
     printf "\
 # credits to virtualenv
 function kerl_deactivate
-{
-    if [ -n "\$_KERL_PATH_REMOVABLE" ]; then
-        PATH=\${PATH//\${_KERL_PATH_REMOVABLE}:/}
-        export PATH
-        unset _KERL_PATH_REMOVABLE
-    fi
-    if [ -n "\$_KERL_MANPATH_REMOVABLE" ]; then
-        MANPATH=\${MANPATH//\${_KERL_MANPATH_REMOVABLE}:/}
-        export MANPATH
-        unset _KERL_MANPATH_REMOVABLE
-    fi
-    if [ -n "\$_KERL_SAVED_REBAR_PLT_DIR" ]; then
-        REBAR_PLT_DIR="\$_KERL_SAVED_REBAR_PLT_DIR"
-        export REBAR_PLT_DIR
-        unset _KERL_SAVED_REBAR_PLT_DIR
-    fi
-    if [ -n "\$_KERL_ACTIVE_DIR" ]; then
-        unset _KERL_ACTIVE_DIR
-    fi
-    if [ -n "\$_KERL_SAVED_PS1" ]; then
-        PS1="\$_KERL_SAVED_PS1"
-        export PS1
-        unset _KERL_SAVED_PS1
-    fi
-    if [ -n "\$BASH" -o -n "\$ZSH_VERSION" ]; then
+    if test -n \"\$_KERL_PATH_REMOVABLE\"
+        set -l OLD_PATH (echo \$PATH | sed -e \"s;\$_KERL_PATH_REMOVABLE;;\")
+        echo -n (eval set -g -x PATH \$OLD_PATH)
+        set -e _KERL_PATH_REMOVABLE
+    end
+    if test -n \"\$_KERL_MANPATH_REMOVABLE\"
+        set -l OLD_MANPATH (echo \$MANPATH | sed -e \"s;\$_KERL_MANPATH_REMOVABLE;;\")
+        echo -n (eval set -g -x MANPATH \$OLD_MANPATH)
+        set -e _KERL_MANPATH_REMOVABLE
+    end
+    if test -n \"\$_KERL_SAVED_REBAR_PLT_DIR\"
+        set -g REBAR_PLT_DIR '\$_KERL_SAVED_REBAR_PLT_DIR'
+        set -e _KERL_SAVED_REBAR_PLT_DIR
+    end
+    if test -n \"\$_KERL_ACTIVE_DIR\"
+        set -e _KERL_ACTIVE_DIR
+    end
+    if test -n \"\$_KERL_SAVED_PS1\"
+        set -g PS1 \"\$_KERL_SAVED_PS1\"
+        set -e _KERL_SAVED_PS1
+    end
+    if test -n \"\$BASH\" -o -n \"\$ZSH_VERSION\"
         hash -r
-    fi
-    if [ ! "\$argv[1]" = "nondestructive" ]; then
-        unset -f kerl_deactivate
-    fi
-}
+    end
+    if test \"\$argv[1]\" != 'nondestructive'
+        functions -e kerl_deactivate
+    end
+end
 kerl_deactivate nondestructive
 
-set -g -x _KERL_SAVED_REBAR_PLT_DIR "\$REBAR_PLT_DIR"
-set -g -x _KERL_PATH_REMOVABLE "$absdir/bin"
-set -g -x PATH \${_KERL_PATH_REMOVABLE} \$PATH
-set -g -x _KERL_MANPATH_REMOVABLE "$absdir/man"
-set -g -x MANPATH \${_KERL_MANPATH_REMOVABLE} \$MANPATH
-set -g -x REBAR_PLT_DIR "$absdir"
-set -g -x _KERL_ACTIVE_DIR "$absdir"
-if [ -f "$KERL_CONFIG" ]
-    . "$KERL_CONFIG"
+set -g -x _KERL_SAVED_REBAR_PLT_DIR \"\$REBAR_PLT_DIR\"
+set -g -x _KERL_PATH_REMOVABLE '$absdir/bin'
+set -g -x PATH \$_KERL_PATH_REMOVABLE \$PATH
+set -g -x _KERL_MANPATH_REMOVABLE '$absdir/man'
+set -g -x MANPATH \$_KERL_MANPATH_REMOVABLE \$MANPATH
+set -g -x REBAR_PLT_DIR '$absdir'
+set -g -x _KERL_ACTIVE_DIR '$absdir'
+if test -f \"\$KERL_CONFIG\"
+    . \"\$KERL_CONFIG\"
 end
 # TODO
-if [ -n "\$KERL_ENABLE_PROMPT" ]
-    set -g -x _KERL_SAVED_PS1 "\$PS1"
-    set -g -x PS1="($argv[1])\$PS1"
+if test -n \"\$KERL_ENABLE_PROMPT\"
+    set -g -x _KERL_SAVED_PS1 \"\$PS1\"
+    set -g -x PS1 \"($argv[1])\$PS1\"
     export PS1
 end
-if [ -n "\$BASH" -o -n "\$ZSH_VERSION" ]
+if test -n \"\$BASH\" -o -n \"\$ZSH_VERSION\"
     hash -r
 end
 " > "$absdir/activate"

--- a/kerl.fish
+++ b/kerl.fish
@@ -1,4 +1,4 @@
-#! /usr/bin/fish
+#! /usr/local/bin/fish
 
 # set CMDNAME (basename (status --current-filename))
 set ERLANG_DOWNLOAD_URL "http://www.erlang.org/download"
@@ -112,7 +112,7 @@ end
 # TODO
 function kerl_get_releases
     curl -L -s $ERLANG_DOWNLOAD_URL/ | \
-        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\/download\/otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
+        sed $SED_OPT -e 's/^.*<[aA] [hH][rR][eE][fF]=\"\otp_src_([-0-9A-Za-z_.]+)\.tar\.gz\">.*$/\1/' \
                      -e '/^R1|^[0-9]/!d' | \
         sed -e 's/^R\(.*\)/\1:R\1/' | sed -e 's/^\([^\:]*\)$/\1-z:\1/' | sort | cut -d':' -f2
 end


### PR DESCRIPTION
Most work was already done so it was just a matter of translating that last bit that generated the `activate` script for the installation.

This should work now:

```
$./kerl.fish build 18.0 18.0
$./kerl.fish install 18.0 ~/erlang/18.0
$ . ~/erlang/18.0/activate
```
